### PR TITLE
decap 'variant', unify NPC features to template names

### DIFF
--- a/lib/frames.json
+++ b/lib/frames.json
@@ -2,6 +2,7 @@
   {
     "id": "mf_störtebeker",
     "variant": "Raleigh",
+    "license_id": "mf_raleigh",
     "license_level": 2,
     "source": "IPS-N",
     "name": "Störtebeker",
@@ -116,6 +117,7 @@
   {
     "id": "mf_micro_monarch",
     "variant": "Monarch",
+    "license_id": "mf_monarch",
     "license_level": 2,
     "source": "SSC",
     "name": "Viceroy",

--- a/lib/frames.json
+++ b/lib/frames.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "mf_störtebeker",
-    "variant": "RALEIGH",
+    "variant": "Raleigh",
     "license_level": 2,
     "source": "IPS-N",
     "name": "Störtebeker",
@@ -115,7 +115,7 @@
   },
   {
     "id": "mf_micro_monarch",
-    "variant": "MONARCH",
+    "variant": "Monarch",
     "license_level": 2,
     "source": "SSC",
     "name": "Viceroy",

--- a/lib/npc_features.json
+++ b/lib/npc_features.json
@@ -4,7 +4,7 @@
     "name": "Abominable",
     "origin": {
       "type": "Template",
-      "name": "HORROR",
+      "name": "Horror",
       "base": false
     },
     "locked": false,
@@ -16,7 +16,7 @@
     "name": "Mutations",
     "origin": {
       "type": "Template",
-      "name": "HORROR",
+      "name": "Horror",
       "base": true
     },
     "locked": false,
@@ -28,7 +28,7 @@
     "name": "Disruptor Whip",
     "origin": {
       "type": "Template",
-      "name": "HORROR",
+      "name": "Horror",
       "base": false
     },
     "locked": false,
@@ -68,7 +68,7 @@
     "name": "Quadruped",
     "origin": {
       "type": "Template",
-      "name": "HORROR",
+      "name": "Horror",
       "base": false
     },
     "locked": false,
@@ -80,7 +80,7 @@
     "name": "Superfluous Extremities",
     "origin": {
       "type": "Template",
-      "name": "HORROR",
+      "name": "Horror",
       "base": false
     },
     "locked": false,
@@ -92,7 +92,7 @@
     "name": "Artificial",
     "origin": {
       "type": "Template",
-      "name": "HORROR",
+      "name": "Horror",
       "base": false
     },
     "locked": false,
@@ -104,7 +104,7 @@
     "name": "Terrifying",
     "origin": {
       "type": "Template",
-      "name": "HORROR",
+      "name": "Horror",
       "base": false
     },
     "locked": false,
@@ -116,7 +116,7 @@
     "name": "Abhorrent Redundancies",
     "origin": {
       "type": "Template",
-      "name": "HORROR",
+      "name": "Horror",
       "base": false
     },
     "locked": false,
@@ -128,7 +128,7 @@
     "name": "Assimilation Maw",
     "origin": {
       "type": "Template",
-      "name": "HORROR",
+      "name": "Horror",
       "base": false
     },
     "locked": false,
@@ -163,7 +163,7 @@
     "name": "Phase-Shift Generator",
     "origin": {
       "type": "Template",
-      "name": "HORROR",
+      "name": "Horror",
       "base": false
     },
     "locked": false,
@@ -184,7 +184,7 @@
     "name": "Construction Tools",
     "origin": {
       "type": "Template",
-      "name": "INDUSTRIAL MECH",
+      "name": "Industrial",
       "base": true
     },
     "locked": false,
@@ -196,7 +196,7 @@
     "name": "Civilian Machine",
     "origin": {
       "type": "Template",
-      "name": "INDUSTRIAL MECH",
+      "name": "Industrial",
       "base": true
     },
     "locked": false,
@@ -208,7 +208,7 @@
     "name": "Bulky Construction",
     "origin": {
       "type": "Template",
-      "name": "INDUSTRIAL MECH",
+      "name": "Industrial",
       "base": true
     },
     "locked": false,
@@ -223,7 +223,7 @@
     "name": "Rock Drill",
     "origin": {
       "type": "Template",
-      "name": "INDUSTRIAL MECH",
+      "name": "Industrial",
       "base": false
     },
     "locked": false,
@@ -263,7 +263,7 @@
     "name": "Fusion Cutter",
     "origin": {
       "type": "Template",
-      "name": "INDUSTRIAL MECH",
+      "name": "Industrial",
       "base": false
     },
     "locked": false,
@@ -314,7 +314,7 @@
     "name": "Industrial Clamps",
     "origin": {
       "type": "Template",
-      "name": "INDUSTRIAL MECH",
+      "name": "Industrial",
       "base": false
     },
     "locked": false,
@@ -350,7 +350,7 @@
     "name": "Rivet Cannon",
     "origin": {
       "type": "Template",
-      "name": "INDUSTRIAL MECH",
+      "name": "Industrial",
       "base": false
     },
     "locked": false,
@@ -395,7 +395,7 @@
     "name": "Buzzsaw",
     "origin": {
       "type": "Template",
-      "name": "INDUSTRIAL MECH",
+      "name": "Industrial",
       "base": false
     },
     "locked": false,
@@ -435,7 +435,7 @@
     "name": "Wrecker",
     "origin": {
       "type": "Template",
-      "name": "INDUSTRIAL MECH",
+      "name": "Industrial",
       "base": false
     },
     "locked": false,
@@ -475,7 +475,7 @@
     "name": "Operatives",
     "origin": {
       "type": "Template",
-      "name": "SPEC OP",
+      "name": "Spec Op",
       "base": true
     },
     "locked": false,
@@ -487,7 +487,7 @@
     "name": "Active Camo",
     "origin": {
       "type": "Template",
-      "name": "SPEC OP",
+      "name": "Spec Op",
       "base": true
     },
     "locked": false,
@@ -508,7 +508,7 @@
     "name": "Deadly Precision",
     "origin": {
       "type": "Template",
-      "name": "SPEC OP",
+      "name": "Spec Op",
       "base": true
     },
     "locked": false,
@@ -520,7 +520,7 @@
     "name": "Coordinated Carnage",
     "origin": {
       "type": "Template",
-      "name": "SPEC OP",
+      "name": "Spec Op",
       "base": true
     },
     "locked": false,
@@ -532,7 +532,7 @@
     "name": "Full-Spectrum Sensor Suite",
     "origin": {
       "type": "Template",
-      "name": "SPEC OP",
+      "name": "Spec Op",
       "base": false
     },
     "locked": false,
@@ -544,7 +544,7 @@
     "name": "Automated Battlefield Awareness Node",
     "origin": {
       "type": "Template",
-      "name": "SPEC OP",
+      "name": "Spec Op",
       "base": false
     },
     "locked": false,
@@ -556,7 +556,7 @@
     "name": "Serrated Machete",
     "origin": {
       "type": "Template",
-      "name": "SPEC OP",
+      "name": "Spec Op",
       "base": false
     },
     "locked": false,
@@ -597,7 +597,7 @@
     "name": "Special Munitions",
     "origin": {
       "type": "Template",
-      "name": "SPEC OP",
+      "name": "Spec Op",
       "base": false
     },
     "locked": false,
@@ -609,7 +609,7 @@
     "name": "Bulwark Mods",
     "origin": {
       "type": "Template",
-      "name": "SPEC OP",
+      "name": "Spec Op",
       "base": false
     },
     "locked": false,
@@ -621,7 +621,7 @@
     "name": "Gyro-Jet Cannon",
     "origin": {
       "type": "Template",
-      "name": "SPEC OP",
+      "name": "Spec Op",
       "base": false
     },
     "locked": false,
@@ -665,7 +665,7 @@
     "name": "Jump Packs",
     "origin": {
       "type": "Template",
-      "name": "SPEC OP",
+      "name": "Spec Op",
       "base": false
     },
     "locked": false,
@@ -677,7 +677,7 @@
     "name": "Null-Perception Coating",
     "origin": {
       "type": "Template",
-      "name": "SPEC OP",
+      "name": "Spec Op",
       "base": false
     },
     "locked": false,

--- a/lib/npc_templates.json
+++ b/lib/npc_templates.json
@@ -21,7 +21,7 @@
   },
   {
     "id": "npct_industrial_mech",
-    "name": "Industrial Mech",
+    "name": "Industrial",
     "description": "Civilian machines built for mining and construction are much more numerous in the galaxy than those purpose-built for combat. Despite their obvious shortcomings, those with little alternatives will often pilot these chassis into battle, turning tools meant to create into tools used to destroy.",
     "base_features": [
       "npcf_construction_tools_industrial_mech",


### PR DESCRIPTION
Decapitalized the Variant fields for the new player frames. 

Also decapitalized the "Name" field for NPC Features, since the NPC Templates had been decapitalized too (one exception was shortening "INDUSTRIAL MECH" to "Industrial" to match the final PDF).  I will note that I'm unsure whether decapitalizing NPC Templates/Classes/names in features is a breaking change or not; I haven't been deep in the GM Toolkit, so this may warrant some testing or reverting for safety.