### PR TITLE
Feat/deploy workflows

### DIFF
--- a/.github/workflows/deploy-lcp.yml
+++ b/.github/workflows/deploy-lcp.yml
@@ -1,0 +1,18 @@
+# This workflow will call org-level reusable workflows for deploying an LCP to itch.io and NPM package to npmjs.com.
+
+name: Deploy LCP
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+    call-butler-publish:
+        uses: massif-press/.github/workflows/butler-publish.yml@master
+        secrets:
+            inherit
+    call-npm-publish:
+        uses: massif-press/.github/workflows/npm-publish.yml@master
+        secrets:
+            inherit

--- a/.github/workflows/deploy-lcp.yml
+++ b/.github/workflows/deploy-lcp.yml
@@ -8,11 +8,11 @@ on:
     types: [created]
 
 jobs:
-    call-butler-publish:
-        uses: massif-press/.github/workflows/butler-publish.yml@master
-        secrets:
-            inherit
-    call-npm-publish:
-        uses: massif-press/.github/workflows/npm-publish.yml@master
-        secrets:
-            inherit
+  call-butler-publish:
+    uses: massif-press/.github/.github/workflows/butler-publish.yml@master
+    secrets:
+      BUTLER_CREDENTIALS: ${{ secrets.BUTLER_CREDENTIALS }}
+  call-npm-publish:
+    uses: massif-press/.github/.github/workflows/npm-publish.yml@master
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/lcp-version-bump.yml
+++ b/.github/workflows/lcp-version-bump.yml
@@ -1,0 +1,10 @@
+# This workflow calls an org-level reusable workflow for incrementing LCP and NPM package versions.
+
+name: LCP Version Bump
+
+on:
+  workflow_dispatch:
+
+jobs:
+  call-bump-version-tag:
+    uses: massif-press/.github/workflows/bump-version-tag.yml@master

--- a/.github/workflows/lcp-version-bump.yml
+++ b/.github/workflows/lcp-version-bump.yml
@@ -4,7 +4,20 @@ name: LCP Version Bump
 
 on:
   workflow_dispatch:
+    inputs:
+      version_level:
+        description: 'Version level to bump'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   call-bump-version-tag:
-    uses: massif-press/.github/workflows/bump-version-tag.yml@master
+    uses: massif-press/.github/.github/workflows/bump-version-tag.yml@master
+    with:
+      version_level: ${{ inputs.version_level }}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,72 @@
+{
+  "name": "@massif/dustgrave-data",
+  "version": "1.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@massif/dustgrave-data",
+      "version": "1.3.0",
+      "license": "GPL-3.0-or-later",
+      "devDependencies": {
+        "zip-lib": "^0.7.3"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
+      }
+    },
+    "node_modules/zip-lib": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/zip-lib/-/zip-lib-0.7.3.tgz",
+      "integrity": "sha512-hp40KYzTJvoaCRr2t6hztlPnVmHYqDUDiIn0hlfAFwVBs3/jwkLy8aZ7NVGHECeWH2Tv8WPwWyR6QuWYarIjJQ==",
+      "dev": true,
+      "dependencies": {
+        "yauzl": "^2.10.0",
+        "yazl": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "build": "node ./scripts/build.js",
-    "cleanup": "node ./scripts/cleanup.js"
+    "cleanup": "node ./scripts/cleanup.js",
+    "test": "node ./scripts/test.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,0 +1,19 @@
+import * as fs from 'fs';
+var currentDir = process.cwd();
+var files = fs.readdirSync('./lib');
+let contents = ""
+let valid = true
+
+files.forEach(filename => {
+    contents = fs.readFileSync(`./lib/${filename}`, 'utf-8')
+    try {
+        JSON.parse(contents)
+    } catch (e) {
+        console.error(`invalid JSON in ${filename}`);
+        valid = false;
+    }
+});
+
+if (!valid) {
+    throw "One or more JSON files are invalid."
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,24 +4,24 @@
 
 buffer-crc32@~0.2.3:
   version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  resolved "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
   integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
 
 fd-slicer@~1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  resolved "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz"
   integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
   dependencies:
     pend "~1.2.0"
 
 pend@~1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  resolved "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
   integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
 yauzl@^2.10.0:
   version "2.10.0"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  resolved "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz"
   integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
   dependencies:
     buffer-crc32 "~0.2.3"
@@ -29,14 +29,14 @@ yauzl@^2.10.0:
 
 yazl@^2.5.1:
   version "2.5.1"
-  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
+  resolved "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz"
   integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
   dependencies:
     buffer-crc32 "~0.2.3"
 
 zip-lib@^0.7.3:
   version "0.7.3"
-  resolved "https://registry.yarnpkg.com/zip-lib/-/zip-lib-0.7.3.tgz#0f0c425569a79f7ef3641208bab53244ff23ff60"
+  resolved "https://registry.npmjs.org/zip-lib/-/zip-lib-0.7.3.tgz"
   integrity sha512-hp40KYzTJvoaCRr2t6hztlPnVmHYqDUDiIn0hlfAFwVBs3/jwkLy8aZ7NVGHECeWH2Tv8WPwWyR6QuWYarIjJQ==
   dependencies:
     yauzl "^2.10.0"


### PR DESCRIPTION
# Description
This PR introduces caller GitHub Workflows that reference shared workflows under the [Massif Press .github repository](https://github.com/massif-press/.github/tree/master/workflows). Builds off of work by OmensPotens in massif-press/long-rim-data#23. The workflows added to this repository include the following:

- **LCP Version Bump**: Manual workflow that finds the current package version, updates it to the next version level (e.g. using "patch" updates from `0.0.1` to `0.0.2`), updates the `lcp_manifest.json` to match, then pushes the changes with a matching version tag.
- **Deploy LCP**: Workflow that checks an LCP has valid JSON files, then deploys an updated package to npm.js and LCP to itch.io upon the creation of a new GitHub release (or optionally triggered manually, if necessary).

## Issue Number
None currently.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
