### PR TITLE
Add Dustmarket reserves.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const data = {
   // manufacturers: require('./lib/manufacturers.json'),
   // mods: require('./lib/mods.json'),
   pilot_gear: require('./lib/pilot_gear.json'),
-  // reserves: require('./lib/reserves.json'),
+  reserves: require('./lib/reserves.json'),
   // sitreps: require('./lib/sitreps.json'),
   // skills: require('./lib/skills.json'),
   // statuses: require('./lib/statuses.json'),

--- a/lib/reserves.json
+++ b/lib/reserves.json
@@ -212,8 +212,8 @@
       {
         "name": "Automated Reflex Suite",
         "activation": "Reaction",
-        "trigger": "When you are hit by an attack.",
-        "detail": "You may make the attack a miss as a reaction."
+        "trigger": "You are hit by an attack.",
+        "detail": "The attack automatically misses."
       }
     ]
   },

--- a/lib/reserves.json
+++ b/lib/reserves.json
@@ -1,0 +1,269 @@
+[
+  {
+    "id": "reserve_military_grade_jetpack",
+    "name": "Military-Grade Jetpack",
+    "type": "Tactical",
+    "label": "Resource",
+    "description": "Can be attached to any hardsuit, allowing the wearer to fly when they move or BOOST."
+  },
+  {
+    "id": "reserve_incendiary_ammo_pilot_scale",
+    "name": "Incendiary Ammo (Pilot-Scale)",
+    "type": "Tactical",
+    "label": "Resource",
+    "description": "Changes a pilot-scale weapon’s damage type to BURN."
+  },
+  {
+    "id": "reserve_pneumatic_enhancer",
+    "name": "Pneumatic Enhancer",
+    "type": "Tactical",
+    "label": "Resource",
+    "description": "Your pilot-scale HEAVY A/C weapons gain the following: On hit: target is knocked PRONE."
+  },
+  {
+    "id": "reserve_sniper_scope",
+    "name": "Sniper Scope",
+    "type": "Tactical",
+    "label": "Resource",
+    "description": "Your pilot-scale signature weapons gain +5 RANGE."
+  },
+  {
+    "id": "reserve_devastator_grenades",
+    "name": "Devastator Grenades",
+    "type": "Tactical",
+    "label": "Resource",
+    "description": "Your Frag Grenades deal +2 damage."
+  },
+  {
+    "id": "reserve_junker_exo_rig",
+    "name": "Junker Exo-Rig",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "You gain +1 ACCURACY to JOCKEY."
+  },
+  {
+    "id": "reserve_crash_cushions",
+    "name": "Crash Cushions",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "When you become STUNNED, you may activate this to not become STUNNED 1/mission."
+  },
+  {
+    "id": "reserve_personal_cloak",
+    "name": "Personal Cloak",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "As a protocol, you become INVISIBLE until the start of your next turn 1/mission.",
+    "actions": [
+      {
+        "name": "Personal Cloak",
+        "activation": "Protocol",
+        "detail": "Become INVISIBLE until the start of your next turn."
+      }
+    ]
+  },
+  {
+    "id": "reserve_precision_targeting_software",
+    "name": "Precision Targeting Software",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "After hitting with an attack, you may activate this to make the attack critical 1/mission."
+  },
+  {
+    "id": "reserve_frostfang_servos",
+    "name": "Frostfang Servos",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "BOOST as a free action 1/mission.",
+    "actions": [
+      {
+        "name": "Frostfang Servos",
+        "activation": "Free",
+        "detail": "BOOST as a free action."
+      }
+    ]
+  },
+  {
+    "id": "reserve_gyro_stabilizers",
+    "name": "Gyro Stabilizers",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "As a protocol, treat all of your weapons as if they aren’t ORDNANCE for the rest of the turn 1/mission.",
+    "actions": [
+      {
+        "name": "Gyro Stabilizers",
+        "activation": "Protocol",
+        "detail": "Treat all of your weapons as if they aren’t ORDNANCE for the rest of the turn."
+      }
+    ]
+  },
+  {
+    "id": "reserve_high_speed_loader",
+    "name": "High-Speed Loader",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "Reload all weapons as a free action 1/mission.",
+    "actions": [
+      {
+        "name": "High-Speed Loader",
+        "activation": "Free",
+        "detail": "Reload all weapons as a free action."
+      }
+    ]
+  },
+  {
+    "id": "reserve_system_flayer",
+    "name": "System Flayer",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "After hitting with INVADE, you may activate this to deal +4 Heat 1/mission."
+  },
+  {
+    "id": "emergency_coolant_reservoir",
+    "name": "Emergency Coolant Reservoir",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "Clear EXPOSED as a free action 1/mission.",
+    "actions": [
+      {
+        "name": "Emergency Coolant Reservoir",
+        "activation": "Free",
+        "detail": "Clear EXPOSED as a free action."
+      }
+    ]
+  },
+  {
+    "id": "reserve_ic_blinkpack",
+    "name": "IC Blinkpack",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "As a protocol, you may teleport whenever you move for the rest of your turn 1/mission.",
+    "actions": [
+      {
+        "name": "IC Blinkpack",
+        "activation": "Protocol",
+        "detail": "As a protocol, you may teleport whenever you move for the rest of your turn."
+      }
+    ]
+  },
+  {
+    "id": "reserve_explosive_knuckles",
+    "name": "Explosive Knuckles",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "After hitting with a RAM, you may activate this to deal 6 explosive damage 1/mission."
+  },
+  {
+    "id": "reserve_ultra_high_penetrator_rounds",
+    "name": "Ultra-High Penetrator Rounds",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "After hitting with a ranged attack, you may activate this to declare that the attack’s damage can’t be reduced 1/mission."
+  },
+  {
+    "id": "reserve_run_off_energy_converter",
+    "name": "Run-Off Energy Converter",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "When you use your CORE POWER, you may activate this to generate a BURST 4 aura of lightning. Hostile characters in the area take 4 energy damage 1/mission."
+  },
+  {
+    "id": "reserve_system_backup",
+    "name": "System Backup",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "When forced to perform a save or check you may activate this to automatically succeed 1/mission."
+  },
+  {
+    "id": "reserve_field_marshal_comp_con",
+    "name": "“Field Marshal” Comp/Con",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "As a quick action, up to two allied characters within SENSORS may each immediately perform a single quick action as a reaction 1/mission.",
+    "actions": [
+      {
+        "name": "“Field Marshal” Comp/Con",
+        "activation": "Quick",
+        "detail": "As a quick action, up to two allied characters within SENSORS may each immediately perform a single quick action as a reaction."
+      }
+    ]
+  },
+  {
+    "id": "reserve_retractable_slab_shields",
+    "name": "Retractable Slab Shields",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "As a protocol, you become IMMOBILIZED until the start of your next turn and gain RESISTANCE to all damage for the same duration 1/mission.",
+    "actions": [
+      {
+        "name": "Retractable Slab Shields",
+        "activation": "Protocol",
+        "detail": "As a protocol, you become IMMOBILIZED until the start of your next turn and gain RESISTANCE to all damage for the same duration."
+      }
+    ]
+  },
+  {
+    "id": "reserve_automated_reflex_suite",
+    "name": "Automated Reflex Suite",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "When you are hit by an attack, you may make the attack a miss as a reaction 1/mission.",
+    "actions": [
+      {
+        "name": "Automated Reflex Suite",
+        "activation": "Reaction",
+        "trigger": "When you are hit by an attack.",
+        "detail": "You may make the attack a miss as a reaction."
+      }
+    ]
+  },
+  {
+    "id": "reserve_bubble_active_personal_shield",
+    "name": "“Bubble” Active Personal Shield",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "As a protocol, gain 4+GRIT OVERSHIELD 1/mission.",
+    "actions": [
+      {
+        "name": "“Bubble” Active Personal Shield",
+        "activation": "Protocol",
+        "detail": "As a protocol, gain 4+GRIT OVERSHIELD."
+      }
+    ]
+  },
+  {
+    "id": "reserve_thermal_optics",
+    "name": "Thermal Optics",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "As a protocol, you may activate this to ignore cover until the end of your turn 1/mission.",
+    "actions": [
+      {
+        "name": "Thermal Optics",
+        "activation": "Protocol",
+        "detail": "As a protocol, you may activate this to ignore cover until the end of your turn."
+      }
+    ]
+  },
+  {
+    "id": "reserve_strain_resistant_actuator",
+    "name": "Strain-Resistant Actuator",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "When you BRACE, you may activate this to suffer no detrimental effects from doing so 1/mission."
+  },
+  {
+    "id": "reserve_hyper_spec_fuel_canister",
+    "name": "Hyper-Spec Fuel Canister",
+    "type": "Mech",
+    "label": "Resource",
+    "description": "As a protocol, you may activate this to gain +1 ACCURACY on all attacks, saves, and checks until the start of your next turn 1/mission.",
+    "actions": [
+      {
+        "name": "Hyper-Spec Fuel Canister",
+        "activation": "Protocol",
+        "detail": "As a protocol, you may activate this to gain +1 ACCURACY on all attacks, saves, and checks until the start of your next turn."
+      }
+    ]
+  }
+]

--- a/lib/reserves.json
+++ b/lib/reserves.json
@@ -58,7 +58,8 @@
       {
         "name": "Personal Cloak",
         "activation": "Protocol",
-        "detail": "Become INVISIBLE until the start of your next turn."
+        "detail": "Become INVISIBLE until the start of your next turn.",
+        "frequency": "1/mission"
       }
     ]
   },
@@ -79,7 +80,8 @@
       {
         "name": "Frostfang Servos",
         "activation": "Free",
-        "detail": "BOOST as a free action."
+        "detail": "BOOST as a free action.",
+        "frequency": "1/mission"
       }
     ]
   },
@@ -93,7 +95,8 @@
       {
         "name": "Gyro Stabilizers",
         "activation": "Protocol",
-        "detail": "Treat all of your weapons as if they aren’t ORDNANCE for the rest of the turn."
+        "detail": "Treat all of your weapons as if they aren’t ORDNANCE for the rest of the turn.",
+        "frequency": "1/mission"
       }
     ]
   },
@@ -107,7 +110,8 @@
       {
         "name": "High-Speed Loader",
         "activation": "Free",
-        "detail": "Reload all weapons as a free action."
+        "detail": "Reload all weapons as a free action.",
+        "frequency": "1/mission"
       }
     ]
   },
@@ -128,7 +132,8 @@
       {
         "name": "Emergency Coolant Reservoir",
         "activation": "Free",
-        "detail": "Clear EXPOSED as a free action."
+        "detail": "Clear EXPOSED as a free action.",
+        "frequency": "1/mission"
       }
     ]
   },
@@ -142,7 +147,8 @@
       {
         "name": "IC Blinkpack",
         "activation": "Protocol",
-        "detail": "As a protocol, you may teleport whenever you move for the rest of your turn."
+        "detail": "As a protocol, you may teleport whenever you move for the rest of your turn.",
+        "frequency": "1/mission"
       }
     ]
   },
@@ -184,7 +190,8 @@
       {
         "name": "“Field Marshal” Comp/Con",
         "activation": "Quick",
-        "detail": "As a quick action, up to two allied characters within SENSORS may each immediately perform a single quick action as a reaction."
+        "detail": "As a quick action, up to two allied characters within SENSORS may each immediately perform a single quick action as a reaction.",
+        "frequency": "1/mission"
       }
     ]
   },
@@ -198,7 +205,8 @@
       {
         "name": "Retractable Slab Shields",
         "activation": "Protocol",
-        "detail": "As a protocol, you become IMMOBILIZED until the start of your next turn and gain RESISTANCE to all damage for the same duration."
+        "detail": "As a protocol, you become IMMOBILIZED until the start of your next turn and gain RESISTANCE to all damage for the same duration.",
+        "frequency": "1/mission"
       }
     ]
   },
@@ -213,7 +221,8 @@
         "name": "Automated Reflex Suite",
         "activation": "Reaction",
         "trigger": "You are hit by an attack.",
-        "detail": "The attack automatically misses."
+        "detail": "The attack automatically misses.",
+        "frequency": "1/mission"
       }
     ]
   },
@@ -227,7 +236,8 @@
       {
         "name": "“Bubble” Active Personal Shield",
         "activation": "Protocol",
-        "detail": "As a protocol, gain 4+GRIT OVERSHIELD."
+        "detail": "As a protocol, gain 4+GRIT OVERSHIELD.",
+        "frequency": "1/mission"
       }
     ]
   },
@@ -241,7 +251,8 @@
       {
         "name": "Thermal Optics",
         "activation": "Protocol",
-        "detail": "As a protocol, you may activate this to ignore cover until the end of your turn."
+        "detail": "As a protocol, you may activate this to ignore cover until the end of your turn.",
+        "frequency": "1/mission"
       }
     ]
   },
@@ -262,7 +273,8 @@
       {
         "name": "Hyper-Spec Fuel Canister",
         "activation": "Protocol",
-        "detail": "As a protocol, you may activate this to gain +1 ACCURACY on all attacks, saves, and checks until the start of your next turn."
+        "detail": "As a protocol, you may activate this to gain +1 ACCURACY on all attacks, saves, and checks until the start of your next turn.",
+        "frequency": "1/mission"
       }
     ]
   }

--- a/lib/reserves.json
+++ b/lib/reserves.json
@@ -37,7 +37,7 @@
   {
     "id": "reserve_junker_exo_rig",
     "name": "Junker Exo-Rig",
-    "type": "Mech",
+    "type": "Tactical",
     "label": "Resource",
     "description": "You gain +1 ACCURACY to JOCKEY."
   },

--- a/lib/reserves.json
+++ b/lib/reserves.json
@@ -46,14 +46,14 @@
     "name": "Crash Cushions",
     "type": "Mech",
     "label": "Resource",
-    "description": "When you become STUNNED, you may activate this to not become STUNNED 1/mission."
+    "description": "1/mission: When you become STUNNED, you may activate this to not become STUNNED."
   },
   {
     "id": "reserve_personal_cloak",
     "name": "Personal Cloak",
     "type": "Mech",
     "label": "Resource",
-    "description": "As a protocol, you become INVISIBLE until the start of your next turn 1/mission.",
+    "description": "1/mission: As a protocol, you become INVISIBLE until the start of your next turn.",
     "actions": [
       {
         "name": "Personal Cloak",
@@ -67,14 +67,14 @@
     "name": "Precision Targeting Software",
     "type": "Mech",
     "label": "Resource",
-    "description": "After hitting with an attack, you may activate this to make the attack critical 1/mission."
+    "description": "1/mission: After hitting with an attack, you may activate this to make the attack critical."
   },
   {
     "id": "reserve_frostfang_servos",
     "name": "Frostfang Servos",
     "type": "Mech",
     "label": "Resource",
-    "description": "BOOST as a free action 1/mission.",
+    "description": "1/mission: BOOST as a free action.",
     "actions": [
       {
         "name": "Frostfang Servos",
@@ -88,7 +88,7 @@
     "name": "Gyro Stabilizers",
     "type": "Mech",
     "label": "Resource",
-    "description": "As a protocol, treat all of your weapons as if they aren’t ORDNANCE for the rest of the turn 1/mission.",
+    "description": "1/mission: As a protocol, treat all of your weapons as if they aren’t ORDNANCE for the rest of the turn.",
     "actions": [
       {
         "name": "Gyro Stabilizers",
@@ -102,7 +102,7 @@
     "name": "High-Speed Loader",
     "type": "Mech",
     "label": "Resource",
-    "description": "Reload all weapons as a free action 1/mission.",
+    "description": "1/mission: Reload all weapons as a free action.",
     "actions": [
       {
         "name": "High-Speed Loader",
@@ -116,14 +116,14 @@
     "name": "System Flayer",
     "type": "Mech",
     "label": "Resource",
-    "description": "After hitting with INVADE, you may activate this to deal +4 Heat 1/mission."
+    "description": "1/mission: After hitting with INVADE, you may activate this to deal +4 Heat."
   },
   {
     "id": "emergency_coolant_reservoir",
     "name": "Emergency Coolant Reservoir",
     "type": "Mech",
     "label": "Resource",
-    "description": "Clear EXPOSED as a free action 1/mission.",
+    "description": "1/mission: Clear EXPOSED as a free action.",
     "actions": [
       {
         "name": "Emergency Coolant Reservoir",
@@ -137,7 +137,7 @@
     "name": "IC Blinkpack",
     "type": "Mech",
     "label": "Resource",
-    "description": "As a protocol, you may teleport whenever you move for the rest of your turn 1/mission.",
+    "description": "1/mission: As a protocol, you may teleport whenever you move for the rest of your turn.",
     "actions": [
       {
         "name": "IC Blinkpack",
@@ -151,35 +151,35 @@
     "name": "Explosive Knuckles",
     "type": "Mech",
     "label": "Resource",
-    "description": "After hitting with a RAM, you may activate this to deal 6 explosive damage 1/mission."
+    "description": "1/mission: After hitting with a RAM, you may activate this to deal 6 explosive damage."
   },
   {
     "id": "reserve_ultra_high_penetrator_rounds",
     "name": "Ultra-High Penetrator Rounds",
     "type": "Mech",
     "label": "Resource",
-    "description": "After hitting with a ranged attack, you may activate this to declare that the attack’s damage can’t be reduced 1/mission."
+    "description": "1/mission: After hitting with a ranged attack, you may activate this to declare that the attack’s damage can’t be reduced."
   },
   {
     "id": "reserve_run_off_energy_converter",
     "name": "Run-Off Energy Converter",
     "type": "Mech",
     "label": "Resource",
-    "description": "When you use your CORE POWER, you may activate this to generate a BURST 4 aura of lightning. Hostile characters in the area take 4 energy damage 1/mission."
+    "description": "1/mission: When you use your CORE POWER, you may activate this to generate a BURST 4 aura of lightning. Hostile characters in the area take 4 energy damage."
   },
   {
     "id": "reserve_system_backup",
     "name": "System Backup",
     "type": "Mech",
     "label": "Resource",
-    "description": "When forced to perform a save or check you may activate this to automatically succeed 1/mission."
+    "description": "1/mission: When forced to perform a save or check you may activate this to automatically succeed."
   },
   {
     "id": "reserve_field_marshal_comp_con",
     "name": "“Field Marshal” Comp/Con",
     "type": "Mech",
     "label": "Resource",
-    "description": "As a quick action, up to two allied characters within SENSORS may each immediately perform a single quick action as a reaction 1/mission.",
+    "description": "1/mission: As a quick action, up to two allied characters within SENSORS may each immediately perform a single quick action as a reaction.",
     "actions": [
       {
         "name": "“Field Marshal” Comp/Con",
@@ -193,7 +193,7 @@
     "name": "Retractable Slab Shields",
     "type": "Mech",
     "label": "Resource",
-    "description": "As a protocol, you become IMMOBILIZED until the start of your next turn and gain RESISTANCE to all damage for the same duration 1/mission.",
+    "description": "1/mission: As a protocol, you become IMMOBILIZED until the start of your next turn and gain RESISTANCE to all damage for the same duration.",
     "actions": [
       {
         "name": "Retractable Slab Shields",
@@ -207,7 +207,7 @@
     "name": "Automated Reflex Suite",
     "type": "Mech",
     "label": "Resource",
-    "description": "When you are hit by an attack, you may make the attack a miss as a reaction 1/mission.",
+    "description": "1/mission: When you are hit by an attack, you may make the attack a miss as a reaction.",
     "actions": [
       {
         "name": "Automated Reflex Suite",
@@ -222,7 +222,7 @@
     "name": "“Bubble” Active Personal Shield",
     "type": "Mech",
     "label": "Resource",
-    "description": "As a protocol, gain 4+GRIT OVERSHIELD 1/mission.",
+    "description": "1/mission: As a protocol, gain 4+GRIT OVERSHIELD.",
     "actions": [
       {
         "name": "“Bubble” Active Personal Shield",
@@ -236,7 +236,7 @@
     "name": "Thermal Optics",
     "type": "Mech",
     "label": "Resource",
-    "description": "As a protocol, you may activate this to ignore cover until the end of your turn 1/mission.",
+    "description": "1/mission: As a protocol, you may activate this to ignore cover until the end of your turn.",
     "actions": [
       {
         "name": "Thermal Optics",
@@ -250,14 +250,14 @@
     "name": "Strain-Resistant Actuator",
     "type": "Mech",
     "label": "Resource",
-    "description": "When you BRACE, you may activate this to suffer no detrimental effects from doing so 1/mission."
+    "description": "1/mission: When you BRACE, you may activate this to suffer no detrimental effects from doing so."
   },
   {
     "id": "reserve_hyper_spec_fuel_canister",
     "name": "Hyper-Spec Fuel Canister",
     "type": "Mech",
     "label": "Resource",
-    "description": "As a protocol, you may activate this to gain +1 ACCURACY on all attacks, saves, and checks until the start of your next turn 1/mission.",
+    "description": "1/mission: As a protocol, you may activate this to gain +1 ACCURACY on all attacks, saves, and checks until the start of your next turn.",
     "actions": [
       {
         "name": "Hyper-Spec Fuel Canister",


### PR DESCRIPTION
Added the reserves table for the Dustmarket 2 table (Dustgrave 30).

Also added the 6 permanent pilot kit items from the Dustmarket 1 table (Dustgrave 29).
They're not true reserves so their inclusion is up to debate.