### PR TITLE
Feat/pg effect environs

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const data = {
   // actions: require('./lib/actions.json'),
   // backgrounds: require('./lib/backgrounds.json'),
   core_bonuses: require('./lib/core_bonuses.json'),
-  // environments: require('./lib/environments.json'),
+  environments: require('./lib/environments.json'),
   frames: require('./lib/frames.json'),
   // manufacturers: require('./lib/manufacturers.json'),
   // mods: require('./lib/mods.json'),

--- a/lib/environments.json
+++ b/lib/environments.json
@@ -1,22 +1,22 @@
 [
-    {
-      "id": "env_chokingdust",
-      "name": "Choking Dust",
-      "description": "The dust clouds choking the battlefield make fighting a chore. Place 5–6 Blast 1 clouds strewn across the battlefield. Characters at least partially within a dust cloud gain soft cover and are Impaired while occupying it."
-    },
-    {
-      "id": "env_arenahazards",
-      "name": "Arena Hazards",
-      "description": "To make the fights more interesting and violent, the arena is full of hazards from whirling buzzsaws to vicious piston spikes. Place four Blast 1 areas on the battlefield. Characters that enter or start their turn inside one of these hazards take 4/5/6 kinetic damage. They may only be damaged by the hazards 1/round. Arena hazards are indestructible. 1/round, these hazards can be targeted with Invade. They have 12/14/16 E-Defense. On a hit, all characters adjacent to the hazard take damage as if they had moved through it."
-    },
-    {
-      "id": "env_mesmertrance",
-      "name": "MesmerTrance",
-      "description": "Player characters without an installed MesmerTrance Dampener are susceptible to the MesmerTrance virus. At the start of each turn, susceptible characters must succeed on a Systems save (11/13/15) or gain 1 MesmerTrance Counter. These counters convey cumulative detrimental effects based on the number of counters accumulated: 1. No effect 2. Gain 1 Heat and an additional 1 Heat at the start of each of the character’s subsequent turns 3. Become Slowed 4. Become Impaired 5. Become Jammed 6. Take 1 stress damage. Affected characters can Stabilize to clear all MesmerTrance Counters."
-    },
-    {
-      "id": "env_automatedrepairstations",
-      "name": "Automated Repair Stations",
-      "description": "Place three Blast 1 areas on the battlefield at least 5 spaces away from each other. NPCs that start their turn at least partially inside those areas regain 3/5/7 HP. These areas can be targeted as if they were objects with 5 Evasion and 10/13/16 HP."
-    }
+  {
+    "id": "env_chokingdust",
+    "name": "Choking Dust",
+    "description": "The dust clouds choking the battlefield make fighting a chore. Place 5–6 Blast 1 clouds strewn across the battlefield. Characters at least partially within a dust cloud gain soft cover and are Impaired while occupying it."
+  },
+  {
+    "id": "env_arenahazards",
+    "name": "Arena Hazards",
+    "description": "To make the fights more interesting and violent, the arena is full of hazards from whirling buzzsaws to vicious piston spikes. Place four Blast 1 areas on the battlefield. Characters that enter or start their turn inside one of these hazards take 4/5/6 kinetic damage. They may only be damaged by the hazards 1/round. Arena hazards are indestructible. 1/round, these hazards can be targeted with Invade. They have 12/14/16 E-Defense. On a hit, all characters adjacent to the hazard take damage as if they had moved through it."
+  },
+  {
+    "id": "env_mesmertrance",
+    "name": "MesmerTrance",
+    "description": "Player characters without an installed MesmerTrance Dampener are susceptible to the MesmerTrance virus. At the start of each turn, susceptible characters must succeed on a Systems save (11/13/15) or gain 1 MesmerTrance Counter. These counters convey cumulative detrimental effects based on the number of counters accumulated: 1. No effect 2. Gain 1 Heat and an additional 1 Heat at the start of each of the character’s subsequent turns 3. Become Slowed 4. Become Impaired 5. Become Jammed 6. Take 1 stress damage. Affected characters can Stabilize to clear all MesmerTrance Counters."
+  },
+  {
+    "id": "env_automatedrepairstations",
+    "name": "Automated Repair Stations",
+    "description": "Place three Blast 1 areas on the battlefield at least 5 spaces away from each other. NPCs that start their turn at least partially inside those areas regain 3/5/7 HP. These areas can be targeted as if they were objects with 5 Evasion and 10/13/16 HP."
+  }
 ]

--- a/lib/environments.json
+++ b/lib/environments.json
@@ -1,0 +1,22 @@
+[
+    {
+      "id": "env_chokingdust",
+      "name": "Choking Dust",
+      "description": "The dust clouds choking the battlefield make fighting a chore. Place 5–6 Blast 1 clouds strewn across the battlefield. Characters at least partially within a dust cloud gain soft cover and are Impaired while occupying it."
+    },
+    {
+      "id": "env_arenahazards",
+      "name": "Arena Hazards",
+      "description": "To make the fights more interesting and violent, the arena is full of hazards from whirling buzzsaws to vicious piston spikes. Place four Blast 1 areas on the battlefield. Characters that enter or start their turn inside one of these hazards take 4/5/6 kinetic damage. They may only be damaged by the hazards 1/round. Arena hazards are indestructible.<br>1/round, these hazards can be targeted with Invade. They have 12/14/16 E-Defense. On a hit, all characters adjacent to the hazard take damage as if they had moved through it."
+    },
+    {
+      "id": "env_mesmertrance",
+      "name": "MesmerTrance",
+      "description": "Player characters without an installed MesmerTrance Dampener (Dustgrave p. 73; provided by the Talons) are susceptible to the MesmerTrance virus.<br>At the start of each turn, susceptible characters must succeed on a Systems save (11/13/15) or gain 1 MesmerTrance Counter. These counters convey cumulative detrimental effects based on the number of counters accumulated:<ol><li>No effect</li><li>Gain 1 Heat and an additional 1 Heat at the start of each of the character’s subsequent turns</li><li>Become Slowed</li><li>Become Impaired</li><li>Become Jammed</li><li>Take 1 stress damage.</li></ol>Affected characters can Stabilize to clear all MesmerTrance Counters."
+    },
+    {
+      "id": "env_automatedrepairstations",
+      "name": "Automated Repair Stations",
+      "description": "Place three Blast 1 areas on the battlefield at least 5 spaces away from each other. NPCs that start their turn at least partially inside those areas regain 3/5/7 HP.<br>These areas can be targeted as if they were objects with 5 Evasion and 10/13/16 HP."
+    }
+]

--- a/lib/environments.json
+++ b/lib/environments.json
@@ -7,16 +7,16 @@
     {
       "id": "env_arenahazards",
       "name": "Arena Hazards",
-      "description": "To make the fights more interesting and violent, the arena is full of hazards from whirling buzzsaws to vicious piston spikes. Place four Blast 1 areas on the battlefield. Characters that enter or start their turn inside one of these hazards take 4/5/6 kinetic damage. They may only be damaged by the hazards 1/round. Arena hazards are indestructible.<br>1/round, these hazards can be targeted with Invade. They have 12/14/16 E-Defense. On a hit, all characters adjacent to the hazard take damage as if they had moved through it."
+      "description": "To make the fights more interesting and violent, the arena is full of hazards from whirling buzzsaws to vicious piston spikes. Place four Blast 1 areas on the battlefield. Characters that enter or start their turn inside one of these hazards take 4/5/6 kinetic damage. They may only be damaged by the hazards 1/round. Arena hazards are indestructible. 1/round, these hazards can be targeted with Invade. They have 12/14/16 E-Defense. On a hit, all characters adjacent to the hazard take damage as if they had moved through it."
     },
     {
       "id": "env_mesmertrance",
       "name": "MesmerTrance",
-      "description": "Player characters without an installed MesmerTrance Dampener (Dustgrave p. 73; provided by the Talons) are susceptible to the MesmerTrance virus.<br>At the start of each turn, susceptible characters must succeed on a Systems save (11/13/15) or gain 1 MesmerTrance Counter. These counters convey cumulative detrimental effects based on the number of counters accumulated:<ol><li>No effect</li><li>Gain 1 Heat and an additional 1 Heat at the start of each of the character’s subsequent turns</li><li>Become Slowed</li><li>Become Impaired</li><li>Become Jammed</li><li>Take 1 stress damage.</li></ol>Affected characters can Stabilize to clear all MesmerTrance Counters."
+      "description": "Player characters without an installed MesmerTrance Dampener are susceptible to the MesmerTrance virus. At the start of each turn, susceptible characters must succeed on a Systems save (11/13/15) or gain 1 MesmerTrance Counter. These counters convey cumulative detrimental effects based on the number of counters accumulated: 1. No effect 2. Gain 1 Heat and an additional 1 Heat at the start of each of the character’s subsequent turns 3. Become Slowed 4. Become Impaired 5. Become Jammed 6. Take 1 stress damage. Affected characters can Stabilize to clear all MesmerTrance Counters."
     },
     {
       "id": "env_automatedrepairstations",
       "name": "Automated Repair Stations",
-      "description": "Place three Blast 1 areas on the battlefield at least 5 spaces away from each other. NPCs that start their turn at least partially inside those areas regain 3/5/7 HP.<br>These areas can be targeted as if they were objects with 5 Evasion and 10/13/16 HP."
+      "description": "Place three Blast 1 areas on the battlefield at least 5 spaces away from each other. NPCs that start their turn at least partially inside those areas regain 3/5/7 HP. These areas can be targeted as if they were objects with 5 Evasion and 10/13/16 HP."
     }
 ]

--- a/lib/pilot_gear.json
+++ b/lib/pilot_gear.json
@@ -3,7 +3,7 @@
     "id": "ms_madrigal_precision_rifle",
     "name": "Madrigal Precision Rifle",
     "type": "Weapon",
-    "description": "<b>Special Rules:</b><br>Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.",
+    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.",
     "tags": [
       {
         "id": "tg_accurate"
@@ -20,7 +20,7 @@
     ],
     "range": [
       {
-        "type": "range",
+        "type": "Range",
         "val": 15
       }
     ],
@@ -35,7 +35,7 @@
     "id": "ms_madrigal_shoulder_launcher",
     "name": "Madrigal Shoulder Launcher",
     "type": "Weapon",
-    "description": "<b>Special Rules:</b><br>Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.",
+    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.",
     "tags": [
       {
         "id": "tg_arcing"
@@ -55,7 +55,7 @@
     ],
     "range": [
       {
-        "type": "range",
+        "type": "Range",
         "val": 10
       },
       {
@@ -74,7 +74,7 @@
     "id": "ms_madrigal_boarding_shotgun",
     "name": "Madrigal Boarding Shotgun",
     "type": "Weapon",
-    "description": "<b>Special Rules:</b><br>Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.",
+    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.",
     "tags": [
       {
         "id": "tg_ap"
@@ -91,7 +91,7 @@
     ],
     "range": [
       {
-        "type": "range",
+        "type": "Range",
         "val": 3
       }
     ],
@@ -106,7 +106,7 @@
     "id": "ms_madrigal_power_crusher",
     "name": "Madrigal Power Crusher",
     "type": "Weapon",
-    "description": "<b>Special Rules:</b><br>Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”. <br><b>On Hit</b>: Target becomes Immobilized and Impaired until the end of its next turn. This weapon automatically hits Terrain and deals 10 AP Kinetic damage.",
+    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.<br><b>On Hit</b>: Target becomes Immobilized and Impaired until the end of its next turn.<br>This weapon automatically hits Terrain and deals 10 AP Kinetic damage.",
     "tags": [
       {
         "id": "tg_unique"
@@ -120,7 +120,7 @@
     ],
     "range": [
       {
-        "type": "threat",
+        "type": "Threat",
         "val": 1
       }
     ],
@@ -135,7 +135,7 @@
     "id": "ms_madrigal_railgun",
     "name": "Madrigal Railgun",
     "type": "Weapon",
-    "description": "<b>Special Rules:</b><br>Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.",
+    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.",
     "tags": [
       {
         "id": "tg_limited",
@@ -153,7 +153,7 @@
     ],
     "range": [
       {
-        "type": "line",
+        "type": "Line",
         "val": 8
       }
     ],
@@ -168,7 +168,7 @@
     "id": "ms_madrigal_disruptor_grenades",
     "name": "Madrigal Disruptor Grenade",
     "type": "Gear",
-    "description": "<b>Special Rules:</b><br>Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”. <br>If your pilot is on foot, you gain the Disruptor Grenade quick action.",
+    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.<br>If your pilot is on foot, you gain the Disruptor Grenade quick action.",
     "actions": [
       {
         "name": "Disruptor Grenade",
@@ -194,7 +194,7 @@
     "id": "ms_madrigal_jump_system",
     "name": "Madrigal Jump System",
     "type": "Gear",
-    "description": "<b>Special Rules:</b><br>Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”. <br>If your pilot is on foot you may Fly when you Boost. You must end this movement on solid ground or begin falling.",
+    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.<br>If your pilot is on foot you may Fly when you Boost. You must end this movement on solid ground or begin falling.",
     "tags": [
       {
         "id": "tg_unique"
@@ -208,7 +208,7 @@
     "id": "ms_madrigal_thermal_visor",
     "name": "Madrigal Thermal Visor",
     "type": "Gear",
-    "description": "<b>Special Rules:</b><br>Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”. <br>If your pilot is on foot your attacks ignore Cover.",
+    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.<br>If your pilot is on foot your attacks ignore Cover.",
     "tags": [
       {
         "id": "tg_unique"
@@ -222,7 +222,7 @@
     "id": "ms_madrigal_active_camo",
     "name": "Madrigal Active Camo",
     "type": "Gear",
-    "description": "<b>Special Rules:</b><br>Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”. <br>If your pilot is on foot, ranged attacks originating from beyond Range 3 treat you as having Hard Cover.",
+    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.<br>If your pilot is on foot, ranged attacks originating from beyond Range 3 treat you as having Hard Cover.",
     "tags": [
       {
         "id": "tg_unique"
@@ -236,7 +236,7 @@
     "id": "ms_madrigal_personal_shield",
     "name": "Madrigal Personal Shield",
     "type": "Gear",
-    "description": "<b>Special Rules:</b><br>Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”. <br>If your pilot is on foot, you gain the Shielded reaction.",
+    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.<br>If your pilot is on foot, you gain the Shielded reaction.",
     "actions": [
       {
         "name": "Shielded",
@@ -264,7 +264,7 @@
     "id": "ms_madrigal_shock_field",
     "name": "Madrigal Shock Field",
     "type": "Gear",
-    "description": "<b>Special Rules:</b><br>Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”. <br>If your pilot is on foot, you gain the Shock Field quick action.",
+    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.<br>If your pilot is on foot, you gain the Shock Field quick action.",
     "actions": [
       {
         "name": "Shock Field",
@@ -286,7 +286,8 @@
     "id": "ms_madrigal_boarding_carapace_armor",
     "name": "Madrigal Boarding Carapace",
     "type": "Armor",
-    "description": "The Madrigal line of personal protection hardsuits, manufactured by Cyprian Industries, represents some of the best void-capable combat suits available. Designed for carrying out and defending against boarding actions, the Madrigal system is modular and can be adjusted to tackle varied tactical situations. While inferior to heavier, dedicated boarding hardsuits and mechs such as the IPS-N Caliban and the Harrison Armory Kutuzov, the Madrigal yet boasts an impressive degree of personal protection without sacrificing mobility or agility. Compact enough to be worn in a mech’s cockpit, the Madrigal is slowly but steadily encroaching on the pilot hardsuits market. Its superior protection, armaments, and auxiliary systems make it an attractive choice for lancers everywhere. <br> <b>Special Rules:</b> <br>If a pilot takes the Madrigal Boarding Carapace they can’t take any pilot weapons or Gear that don’t have “Madrigal” in the name. Madrigal weapons and Gear may only be equipped by pilots wearing the Madrigal Boarding Carapace. While wearing the carapace, you may only Dismount or Eject before your mech has acted for the turn (excluding protocols). If you aren’t in your mech and it is being controlled by another person or an AI, it may only perform a single quick action and standard movement on each of its turns. It may perform protocols and reactions as normal. When your mech Braces during this time it also loses its remaining quick action. These effects last until you retake control as a protocol. The Madrigal Boarding Carapace counts as one of the two Exotic Gear systems you may have installed at a time, but Madrigal weapons and Gear do not.",
+    "effect": "If a pilot takes the Madrigal Boarding Carapace they can’t take any pilot weapons or Gear that don’t have “Madrigal” in the name. Madrigal weapons and Gear may only be equipped by pilots wearing the Madrigal Boarding Carapace.<br>While wearing the carapace, you may only Dismount or Eject before your mech has acted for the turn (excluding protocols).<br>If you aren’t in your mech and it is being controlled by another person or an AI, it may only perform a single quick action and standard movement on each of its turns. It may perform protocols and reactions as normal. When your mech Braces during this time it also loses its remaining quick action. These effects last until you retake control as a protocol.<br>The Madrigal Boarding Carapace counts as one of the two Exotic Gear systems you may have installed at a time, but Madrigal weapons and Gear do not.",
+    "description": "The Madrigal line of personal protection hardsuits, manufactured by Cyprian Industries, represents some of the best void-capable combat suits available. Designed for carrying out and defending against boarding actions, the Madrigal system is modular and can be adjusted to tackle varied tactical situations. While inferior to heavier, dedicated boarding hardsuits and mechs such as the IPS-N Caliban and the Harrison Armory Kutuzov, the Madrigal yet boasts an impressive degree of personal protection without sacrificing mobility or agility. Compact enough to be worn in a mech’s cockpit, the Madrigal is slowly but steadily encroaching on the pilot hardsuits market. Its superior protection, armaments, and auxiliary systems make it an attractive choice for lancers everywhere.",
     "tags": [
       {
         "id": "tg_exotic"

--- a/lib/pilot_gear.json
+++ b/lib/pilot_gear.json
@@ -3,7 +3,7 @@
     "id": "ms_madrigal_precision_rifle",
     "name": "Madrigal Precision Rifle",
     "type": "Weapon",
-    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.",
+    "effect": "<p><b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.</p>",
     "tags": [
       {
         "id": "tg_accurate"
@@ -35,7 +35,7 @@
     "id": "ms_madrigal_shoulder_launcher",
     "name": "Madrigal Shoulder Launcher",
     "type": "Weapon",
-    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.",
+    "effect": "<p><b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.</p>",
     "tags": [
       {
         "id": "tg_arcing"
@@ -74,7 +74,7 @@
     "id": "ms_madrigal_boarding_shotgun",
     "name": "Madrigal Boarding Shotgun",
     "type": "Weapon",
-    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.",
+    "effect": "<p><b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.</p>",
     "tags": [
       {
         "id": "tg_ap"
@@ -106,7 +106,7 @@
     "id": "ms_madrigal_power_crusher",
     "name": "Madrigal Power Crusher",
     "type": "Weapon",
-    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.<br><b>On Hit</b>: Target becomes Immobilized and Impaired until the end of its next turn.<br>This weapon automatically hits Terrain and deals 10 AP Kinetic damage.",
+    "effect": "<p><b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.</p><p><b>On Hit</b>: Target becomes Immobilized and Impaired until the end of its next turn.</p><p>This weapon automatically hits Terrain and deals 10 AP Kinetic damage.</p>",
     "tags": [
       {
         "id": "tg_unique"
@@ -135,7 +135,7 @@
     "id": "ms_madrigal_railgun",
     "name": "Madrigal Railgun",
     "type": "Weapon",
-    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.",
+    "effect": "<p><b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.</p>",
     "tags": [
       {
         "id": "tg_limited",
@@ -168,7 +168,7 @@
     "id": "ms_madrigal_disruptor_grenades",
     "name": "Madrigal Disruptor Grenade",
     "type": "Gear",
-    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.<br>If your pilot is on foot, you gain the Disruptor Grenade quick action.",
+    "effect": "<p><b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.</p><p>If your pilot is on foot, you gain the Disruptor Grenade quick action.</p>",
     "actions": [
       {
         "name": "Disruptor Grenade",
@@ -194,7 +194,7 @@
     "id": "ms_madrigal_jump_system",
     "name": "Madrigal Jump System",
     "type": "Gear",
-    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.<br>If your pilot is on foot you may Fly when you Boost. You must end this movement on solid ground or begin falling.",
+    "effect": "<p><b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.</p><p>If your pilot is on foot you may Fly when you Boost. You must end this movement on solid ground or begin falling.</p>",
     "tags": [
       {
         "id": "tg_unique"
@@ -208,7 +208,7 @@
     "id": "ms_madrigal_thermal_visor",
     "name": "Madrigal Thermal Visor",
     "type": "Gear",
-    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.<br>If your pilot is on foot your attacks ignore Cover.",
+    "effect": "<p><b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.</p><p>If your pilot is on foot your attacks ignore Cover.</p>",
     "tags": [
       {
         "id": "tg_unique"
@@ -222,7 +222,7 @@
     "id": "ms_madrigal_active_camo",
     "name": "Madrigal Active Camo",
     "type": "Gear",
-    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.<br>If your pilot is on foot, ranged attacks originating from beyond Range 3 treat you as having Hard Cover.",
+    "effect": "<p><b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.</p><p>If your pilot is on foot, ranged attacks originating from beyond Range 3 treat you as having Hard Cover.</p>",
     "tags": [
       {
         "id": "tg_unique"
@@ -236,7 +236,7 @@
     "id": "ms_madrigal_personal_shield",
     "name": "Madrigal Personal Shield",
     "type": "Gear",
-    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.<br>If your pilot is on foot, you gain the Shielded reaction.",
+    "effect": "<p><b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.</p><p>If your pilot is on foot, you gain the Shielded reaction.</p>",
     "actions": [
       {
         "name": "Shielded",
@@ -264,7 +264,7 @@
     "id": "ms_madrigal_shock_field",
     "name": "Madrigal Shock Field",
     "type": "Gear",
-    "effect": "<b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.<br>If your pilot is on foot, you gain the Shock Field quick action.",
+    "effect": "<p><b>Requirement</b>: Weapons and Gear with “Madrigal” in the name may only be equipped if the Pilot is wearing the “Madrigal Boarding Carapace”.</p><p>If your pilot is on foot, you gain the Shock Field quick action.</p>",
     "actions": [
       {
         "name": "Shock Field",
@@ -286,7 +286,7 @@
     "id": "ms_madrigal_boarding_carapace_armor",
     "name": "Madrigal Boarding Carapace",
     "type": "Armor",
-    "effect": "If a pilot takes the Madrigal Boarding Carapace they can’t take any pilot weapons or Gear that don’t have “Madrigal” in the name. Madrigal weapons and Gear may only be equipped by pilots wearing the Madrigal Boarding Carapace.<br>While wearing the carapace, you may only Dismount or Eject before your mech has acted for the turn (excluding protocols).<br>If you aren’t in your mech and it is being controlled by another person or an AI, it may only perform a single quick action and standard movement on each of its turns. It may perform protocols and reactions as normal. When your mech Braces during this time it also loses its remaining quick action. These effects last until you retake control as a protocol.<br>The Madrigal Boarding Carapace counts as one of the two Exotic Gear systems you may have installed at a time, but Madrigal weapons and Gear do not.",
+    "effect": "<p>If a pilot takes the Madrigal Boarding Carapace they can’t take any pilot weapons or Gear that don’t have “Madrigal” in the name. Madrigal weapons and Gear may only be equipped by pilots wearing the Madrigal Boarding Carapace.</p><p>While wearing the carapace, you may only Dismount or Eject before your mech has acted for the turn (excluding protocols).</p><p>If you aren’t in your mech and it is being controlled by another person or an AI, it may only perform a single quick action and standard movement on each of its turns. It may perform protocols and reactions as normal. When your mech Braces during this time it also loses its remaining quick action. These effects last until you retake control as a protocol.</p><p>The Madrigal Boarding Carapace counts as one of the two Exotic Gear systems you may have installed at a time, but Madrigal weapons and Gear do not.</p>",
     "description": "The Madrigal line of personal protection hardsuits, manufactured by Cyprian Industries, represents some of the best void-capable combat suits available. Designed for carrying out and defending against boarding actions, the Madrigal system is modular and can be adjusted to tackle varied tactical situations. While inferior to heavier, dedicated boarding hardsuits and mechs such as the IPS-N Caliban and the Harrison Armory Kutuzov, the Madrigal yet boasts an impressive degree of personal protection without sacrificing mobility or agility. Compact enough to be worn in a mech’s cockpit, the Madrigal is slowly but steadily encroaching on the pilot hardsuits market. Its superior protection, armaments, and auxiliary systems make it an attractive choice for lancers everywhere.",
     "tags": [
       {

--- a/lib/pilot_gear.json
+++ b/lib/pilot_gear.json
@@ -16,6 +16,9 @@
       },
       {
         "id": "tg_unique"
+      },
+      {
+        "id": "tg_pilot_weapon"
       }
     ],
     "range": [
@@ -51,6 +54,9 @@
       },
       {
         "id": "tg_exotic"
+      },
+      {
+        "id": "tg_pilot_weapon"
       }
     ],
     "range": [
@@ -87,6 +93,9 @@
       },
       {
         "id": "tg_exotic"
+      },
+      {
+        "id": "tg_pilot_weapon"
       }
     ],
     "range": [
@@ -116,6 +125,9 @@
       },
       {
         "id": "tg_exotic"
+      },
+      {
+        "id": "tg_pilot_weapon"
       }
     ],
     "range": [
@@ -149,6 +161,9 @@
       },
       {
         "id": "tg_exotic"
+      },
+      {
+        "id": "tg_pilot_weapon"
       }
     ],
     "range": [
@@ -187,6 +202,9 @@
       },
       {
         "id": "tg_exotic"
+      },
+      {
+        "id": "tg_gear"
       }
     ]
   },
@@ -201,6 +219,9 @@
       },
       {
         "id": "tg_exotic"
+      },
+      {
+        "id": "tg_gear"
       }
     ]
   },
@@ -215,6 +236,9 @@
       },
       {
         "id": "tg_exotic"
+      },
+      {
+        "id": "tg_gear"
       }
     ]
   },
@@ -229,6 +253,9 @@
       },
       {
         "id": "tg_exotic"
+      },
+      {
+        "id": "tg_gear"
       }
     ]
   },
@@ -257,6 +284,9 @@
       {
         "id": "tg_limited",
         "val": 2
+      },
+      {
+        "id": "tg_gear"
       }
     ]
   },
@@ -279,6 +309,9 @@
       },
       {
         "id": "tg_exotic"
+      },
+      {
+        "id": "tg_gear"
       }
     ]
   },
@@ -291,6 +324,9 @@
     "tags": [
       {
         "id": "tg_exotic"
+      },
+      {
+        "id": "tg_personal_armor"
       }
     ],
     "bonuses": [

--- a/lib/reserves.json
+++ b/lib/reserves.json
@@ -11,21 +11,39 @@
     "name": "Incendiary Ammo (Pilot-Scale)",
     "type": "Tactical",
     "label": "Resource",
-    "description": "Changes a pilot-scale weapon’s damage type to BURN."
+    "description": "Changes a pilot-scale weapon’s damage type to BURN.",
+    "synergies": [
+      {
+        "locations": ["pilot_weapon"],
+        "detail": "Changes a pilot-scale weapon’s damage type to BURN."
+      }
+    ]
   },
   {
     "id": "reserve_pneumatic_enhancer",
     "name": "Pneumatic Enhancer",
     "type": "Tactical",
     "label": "Resource",
-    "description": "Your pilot-scale HEAVY A/C weapons gain the following: On hit: target is knocked PRONE."
+    "description": "Your pilot-scale HEAVY A/C weapons gain the following: On hit: target is knocked PRONE.",
+    "synergies": [
+      {
+        "locations": ["pilot_weapon"],
+        "detail": "Your pilot-scale HEAVY A/C weapons gain the following: On hit: target is knocked PRONE."
+      }
+    ]
   },
   {
     "id": "reserve_sniper_scope",
     "name": "Sniper Scope",
     "type": "Tactical",
     "label": "Resource",
-    "description": "Your pilot-scale signature weapons gain +5 RANGE."
+    "description": "Your pilot-scale signature weapons gain +5 RANGE.",
+    "synergies": [
+      {
+        "locations": ["pilot_weapon"],
+        "detail": "Your pilot-scale signature weapons gain +5 RANGE."
+      }
+    ]
   },
   {
     "id": "reserve_devastator_grenades",
@@ -68,7 +86,14 @@
     "name": "Precision Targeting Software",
     "type": "Mech",
     "label": "Resource",
-    "description": "1/mission: After hitting with an attack, you may activate this to make the attack critical."
+    "description": "1/mission: After hitting with an attack, you may activate this to make the attack critical.",
+    "synergies": [
+      {
+        "locations": ["weapon"],
+        "weapon_types": ["any"],
+        "detail": "1/mission: After hitting with an attack, you may activate this to make the attack critical."
+      }
+    ]
   },
   {
     "id": "reserve_frostfang_servos",
@@ -82,6 +107,12 @@
         "activation": "Free",
         "detail": "BOOST as a free action.",
         "frequency": "1/mission"
+      }
+    ],
+    "synergies": [
+      {
+        "locations": ["boost"],
+        "detail": "1/mission: BOOST as a free action."
       }
     ]
   },
@@ -97,6 +128,12 @@
         "activation": "Protocol",
         "detail": "Treat all of your weapons as if they aren’t ORDNANCE for the rest of the turn.",
         "frequency": "1/mission"
+      }
+    ],
+    "synergies": [
+      {
+        "locations": ["weapon"],
+        "detail": "1/mission: As a protocol, treat all of your weapons as if they aren’t ORDNANCE for the rest of the turn."
       }
     ]
   },
@@ -120,7 +157,13 @@
     "name": "System Flayer",
     "type": "Mech",
     "label": "Resource",
-    "description": "1/mission: After hitting with INVADE, you may activate this to deal +4 Heat."
+    "description": "1/mission: After hitting with INVADE, you may activate this to deal +4 Heat.",
+    "synergies": [
+      {
+        "locations": ["tech_attack"],
+        "detail": "1/mission: After hitting with INVADE, you may activate this to deal +4 Heat."
+      }
+    ]
   },
   {
     "id": "emergency_coolant_reservoir",
@@ -150,6 +193,12 @@
         "detail": "As a protocol, you may teleport whenever you move for the rest of your turn.",
         "frequency": "1/mission"
       }
+    ],
+    "synergies": [
+      {
+        "locations": ["move"],
+        "detail": "1/mission: As a protocol, you may teleport whenever you move for the rest of your turn."
+      }
     ]
   },
   {
@@ -157,28 +206,53 @@
     "name": "Explosive Knuckles",
     "type": "Mech",
     "label": "Resource",
-    "description": "1/mission: After hitting with a RAM, you may activate this to deal 6 explosive damage."
+    "description": "1/mission: After hitting with a RAM, you may activate this to deal 6 explosive damage.",
+    "synergies": [
+      {
+        "locations": ["ram"],
+        "detail": "1/mission: After hitting with a RAM, you may activate this to deal 6 explosive damage."
+      }
+    ]
   },
   {
     "id": "reserve_ultra_high_penetrator_rounds",
     "name": "Ultra-High Penetrator Rounds",
     "type": "Mech",
     "label": "Resource",
-    "description": "1/mission: After hitting with a ranged attack, you may activate this to declare that the attack’s damage can’t be reduced."
+    "description": "1/mission: After hitting with a ranged attack, you may activate this to declare that the attack’s damage can’t be reduced.",
+    "synergies": [
+      {
+        "locations": ["weapon"],
+        "weapon_types": ["any"],
+        "detail": "1/mission: After hitting with a ranged attack, you may activate this to declare that the attack’s damage can’t be reduced."
+      }
+    ]
   },
   {
     "id": "reserve_run_off_energy_converter",
     "name": "Run-Off Energy Converter",
     "type": "Mech",
     "label": "Resource",
-    "description": "1/mission: When you use your CORE POWER, you may activate this to generate a BURST 4 aura of lightning. Hostile characters in the area take 4 energy damage."
+    "description": "1/mission: When you use your CORE POWER, you may activate this to generate a BURST 4 aura of lightning. Hostile characters in the area take 4 energy damage.",
+    "synergies": [
+      {
+        "locations": ["core_power"],
+        "detail": "1/mission: When you use your CORE POWER, you may activate this to generate a BURST 4 aura of lightning. Hostile characters in the area take 4 energy damage."
+      }
+    ]
   },
   {
     "id": "reserve_system_backup",
     "name": "System Backup",
     "type": "Mech",
     "label": "Resource",
-    "description": "1/mission: When forced to perform a save or check you may activate this to automatically succeed."
+    "description": "1/mission: When forced to perform a save or check you may activate this to automatically succeed.",
+    "synergies": [
+      {
+        "locations": ["skill_check"],
+        "detail": "1/mission: When forced to perform a save or check you may activate this to automatically succeed."
+      }
+    ]
   },
   {
     "id": "reserve_field_marshal_comp_con",
@@ -239,6 +313,12 @@
         "detail": "As a protocol, gain 4+GRIT OVERSHIELD.",
         "frequency": "1/mission"
       }
+    ],
+    "synergies": [
+      {
+        "locations": ["overshield"],
+        "detail": "1/mission: As a protocol, gain 4+GRIT OVERSHIELD."
+      }
     ]
   },
   {
@@ -254,6 +334,13 @@
         "detail": "As a protocol, you may activate this to ignore cover until the end of your turn.",
         "frequency": "1/mission"
       }
+    ],
+    "synergies": [
+      {
+        "locations": ["weapon"],
+        "weapon_types": ["any"],
+        "detail": "As a protocol, you may activate this to ignore cover until the end of your turn."
+      }
     ]
   },
   {
@@ -261,7 +348,13 @@
     "name": "Strain-Resistant Actuator",
     "type": "Mech",
     "label": "Resource",
-    "description": "1/mission: When you BRACE, you may activate this to suffer no detrimental effects from doing so."
+    "description": "1/mission: When you BRACE, you may activate this to suffer no detrimental effects from doing so.",
+    "synergies": [
+      {
+        "locations": ["brace"],
+        "detail": "1/mission: When you BRACE, you may activate this to suffer no detrimental effects from doing so."
+      }
+    ]
   },
   {
     "id": "reserve_hyper_spec_fuel_canister",
@@ -275,6 +368,12 @@
         "activation": "Protocol",
         "detail": "As a protocol, you may activate this to gain +1 ACCURACY on all attacks, saves, and checks until the start of your next turn.",
         "frequency": "1/mission"
+      }
+    ],
+    "synergies": [
+      {
+        "locations": ["skill_check"],
+        "detail": "1/mission: When forced to perform a save or check you may activate this to automatically succeed."
       }
     ]
   }


### PR DESCRIPTION
# Description

Leverages the newly-implemented "effect" field for pilot gear in Comp/Con. Additionally adds new Environments introduced in Dustgrave.

In addition, adds Pilot Gear tags to all Madrigal gear. Depends on massif-press/lancer-data#197 to be implemented within CompCon first (as that PR introduces the Pilot Weapon tag).

UPDATE: Also added some synergies to the Reserves (even if they aren't all used by CompCon at the moment).